### PR TITLE
Resolve dynamic resource allocation unknown revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module k8s.io/cloud-provider-gcp
 
 go 1.19
 
+// k8s.io/kubernetes imports dynamic-resource-allocation from the staging repos as of 1.26.0.
+// This means that `go list -mod readonly -m -f '{{ if not .Main }}{{ .String }}{{ end }}' all` fails
+// as it cannot find the v0.0.0 revision. This is needed to resolve that error and fixes
+// the ART builds.
+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0
+
 require (
 	cloud.google.com/go v0.99.0
 	github.com/evanphx/json-patch v4.12.0+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1428,6 +1428,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0
 # cloud.google.com/go => cloud.google.com/go v0.75.0
 # github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.6
 # github.com/go-openapi/swag => github.com/go-openapi/swag v0.19.7


### PR DESCRIPTION
Currently we are unable to build this image because of an issue with the go.mod listing that runs within cachito as part of the build process.
```
The command "go list -mod readonly -m -f {{ if not .Main }}{{ .String }}{{ end }} all" failed with: go: k8s.io/dynamic-resource-allocation@v0.0.0: reading https://cachito-athens.cachito-prod.svc/k8s.io/dynamic-resource-allocation/@v/v0.0.0.info: 404 Not Found
```
By replacing the dependency, even though we don't use it, we give go.mod a version to use when it's trying to resolve dependencies and this resolves the issue, the failing command now works.

XREF: https://redhat-internal.slack.com/archives/CBZHF4DHC/p1676363138679649