### PR TITLE
[release-4.15] OCPBUGS-30970: Update gcr-credential-provider.spec

### DIFF
--- a/gcr-credential-provider.spec
+++ b/gcr-credential-provider.spec
@@ -44,7 +44,7 @@
 # Customize from here.
 #
 
-%global golang_version 1.21.0
+%global golang_version 1.20.0
 %{!?version: %global version 0.0.1}
 %{!?release: %global release 1}
 %global package_name gcr-credential-provider 


### PR DESCRIPTION
Changes golang required version to 1.20