### PR TITLE
OCPBUGS-43089: Do not check for PodCIDR when determining if node is in the default subnetwork.

### DIFF
--- a/providers/gce/gce_loadbalancer_internal_test.go
+++ b/providers/gce/gce_loadbalancer_internal_test.go
@@ -213,7 +213,7 @@ func TestEnsureInstanceGroupFromDefaultNetworkMultiSubnetClusterMode(t *testing.
 	nodes[0].Labels[labelGKESubnetworkName] = "defaultSubnet"
 	// node with a label of a non-matching subnet
 	nodes[1].Labels[labelGKESubnetworkName] = "anotherSubnet"
-	// node with no label but a PodCIDR
+	// node with no label but with PodCIDR
 	nodes[2].Spec.PodCIDR = "10.0.5.0/24"
 	// node[3] has no label nor PodCIDR
 	nodes[3].Spec.PodCIDR = ""
@@ -230,7 +230,7 @@ func TestEnsureInstanceGroupFromDefaultNetworkMultiSubnetClusterMode(t *testing.
 	require.NoError(t, err)
 	instances, err := gce.ListInstancesInInstanceGroup(url.Key.Name, url.Key.Zone, "ALL")
 	require.NoError(t, err)
-	assert.Len(t, instances, 3, "Incorrect number of Instances in the group")
+	assert.Len(t, instances, 4, "Incorrect number of Instances in the group")
 	var instanceURLs []string
 	for _, inst := range instances {
 		instanceURLs = append(instanceURLs, inst.Instance)
@@ -244,8 +244,8 @@ func TestEnsureInstanceGroupFromDefaultNetworkMultiSubnetClusterMode(t *testing.
 	if !hasInstanceForNode(instances, nodes[2]) {
 		t.Errorf("expected n3 to be in instances but it contained %+v", instanceURLs)
 	}
-	if hasInstanceForNode(instances, nodes[3]) {
-		t.Errorf("expected n4 to NOT be in instances but it was included %+v", instanceURLs)
+	if !hasInstanceForNode(instances, nodes[3]) {
+		t.Errorf("expected n4 to be in instances but it contained %+v", instanceURLs)
 	}
 	if !hasInstanceForNode(instances, nodes[4]) {
 		t.Errorf("expected n5 to be in instances but it contained %+v", instanceURLs)
@@ -348,7 +348,7 @@ func TestRemoveNodesInNonDefaultNetworks(t *testing.T) {
 					Name: "nodeInUnknownSubnet",
 				},
 			},
-			shouldBeInDefaultSubnet: false,
+			shouldBeInDefaultSubnet: true,
 		},
 	}
 	var nodes []*v1.Node


### PR DESCRIPTION
Manual cherry-pick that will be dropped when we rebase, needed to satisfy backporting requirements to 4.18.

Original commit message:

gce_loadbalancer_internal.go - Do not check for PodCIDR when determining if node is in the default subnetwork.

The problem with PodCIDR check is that it can skip a freshly added node when PodCIDR is not yet set. Service provisioning will succeed. Then, when PodCIDR is added to the node, this code https://github.com/kubernetes/kubernetes/blob/da215bf06a3b8ac3da4e0adb110dc5acc7f61fe1/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L756 can decide to not sync the service anymore. As a result the node would never be added to the LB backends. Possible effect on a multi-subnet cluster: the controller may attempt to add a node from a non-default network to the Instance Group. This would fail, error would be returned by `updateInternalLoadBalancer` function and as a result the service would be retried. At some point the retry will see the updated node with the subnetwork label and skip it. Manual testing with a custom CCM with this change showed that the label is added immediately and the error doesn't even happen. The PodCIDR check was supposed to be a safety check for situations where subnetwork label is not present and node subnet can not be determined. Since PodCIDR was supposed to be set in the same place as PodCIDR the assumption was that node with PodCIDR but no label must be from the default subnet.