### PR TITLE
OCPBUGS-78471: Fix OSD ILB bug

### DIFF
--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -742,7 +742,7 @@ func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]s
 	}
 
 	zonedNodes := splitNodesByZone(filteredNodes)
-	klog.V(2).Infof("ensureInternalInstanceGroups(%v): %d nodes over %d zones in region %v", name, len(nodes), len(zonedNodes), g.region)
+	klog.V(2).Infof("ensureInternalInstanceGroups(%v): %d filtered nodes over %d zones in region %v", name, len(filteredNodes), len(zonedNodes), g.region)
 
 	emptyZoneNodesNames := sets.NewString()
 	for _, n := range zonedNodes[""] {

--- a/providers/gce/gce_loadbalancer_internal_openshift.go
+++ b/providers/gce/gce_loadbalancer_internal_openshift.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 )
 
 // filterNodesWithExistingExternalInstanceGroups filters out nodes that are already managed by
@@ -110,8 +111,11 @@ func filterNodeObjectFromName(nodesInZone []*v1.Node, nodeNames []string) []*v1.
 	filteredNodes := []*v1.Node{}
 
 	for _, node := range nodesInZone {
-		if slices.Contains(nodeNames, node.Name) {
+		canonicalName := canonicalizeInstanceName(node.Name)
+		if slices.Contains(nodeNames, canonicalName) {
 			filteredNodes = append(filteredNodes, node)
+		} else {
+			klog.Warningf("filterNodeObjectFromName: node %q (canonical: %q) not found in GCE instance names %v", node.Name, canonicalName, nodeNames)
 		}
 	}
 	return filteredNodes
@@ -143,12 +147,27 @@ func (g *Cloud) evaluateExternalInstanceGroup(ig *compute.InstanceGroup, zone st
 	// If all instances in this external instance group are also in our zone's node list,
 	// or they all have the node instance prefix, we can reuse this instance group instead
 	// of creating our own internal instance group
-	shouldReuse = gceHostNamesInZone.HasAll(instanceNames.UnsortedList()...) || g.allHaveNodePrefix(instanceNames.UnsortedList())
+	hasAll := gceHostNamesInZone.HasAll(instanceNames.UnsortedList()...)
+	allHavePrefix := g.allHaveNodePrefix(instanceNames.UnsortedList())
+	shouldReuse = hasAll || allHavePrefix
+	klog.V(2).Infof("evaluateExternalInstanceGroup(%v): shouldReuse=%v (hasAll=%v, allHavePrefix=%v), instances=%v", ig.Name, shouldReuse, hasAll, allHavePrefix, instanceNames.UnsortedList())
 
 	return shouldReuse, instanceNames, nil
 }
 
 // allHaveNodePrefix checks if all instances have the cluster's node instance prefix.
+//
+// DO NOT REMOVE. This is load-bearing for all OCP GCP clusters.
+//
+// The OpenShift installer creates per-zone master instance groups (e.g.
+// <infra>-master-<zone>). During CAPG installs (OCPBUGS-35256), the bootstrap
+// node is placed in the same master IG as a control plane node. The bootstrap
+// node is not a k8s node, so HasAll rejects the master IG. Without this prefix
+// fallback the CCM then tries to add the master to its own k8s-ig, which fails
+// with INSTANCE_IN_MULTIPLE_LOAD_BALANCED_IGS (master is already in the
+// installer's IG). It then tries to add the worker to that same k8s-ig
+// alongside the master, which fails with wrongSubnetwork (masters and workers
+// are on different subnets).
 func (g *Cloud) allHaveNodePrefix(instances []string) bool {
 	for _, instance := range instances {
 		if !strings.HasPrefix(instance, g.nodeInstancePrefix) {

--- a/providers/gce/gce_loadbalancer_internal_openshift_test.go
+++ b/providers/gce/gce_loadbalancer_internal_openshift_test.go
@@ -1,0 +1,248 @@
+//go:build !providerless
+
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/api/compute/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Test constants matching real OSD cluster topology from OCPBUGS-78471.
+// node-instance-prefix and external-instance-groups-prefix are the same
+// value (the infra name), and all node names are FQDNs.
+const testInfraName = "test-cluster-a1b2c"
+
+func fqdnName(short string) string {
+	return fmt.Sprintf("%s.c.%s.internal", short, "test-project")
+}
+
+func TestFilterNodeObjectFromName(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct {
+		nodes    []*v1.Node
+		names    []string
+		expected []string
+	}{
+		"FQDN node names match GCE short names": {
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: fqdnName(testInfraName + "-worker-a-wnjp7")}},
+				{ObjectMeta: metav1.ObjectMeta{Name: fqdnName(testInfraName + "-worker-b-s48dq")}},
+			},
+			names: []string{
+				testInfraName + "-worker-a-wnjp7",
+				testInfraName + "-worker-b-s48dq",
+			},
+			expected: []string{
+				fqdnName(testInfraName + "-worker-a-wnjp7"),
+				fqdnName(testInfraName + "-worker-b-s48dq"),
+			},
+		},
+		"short node names still match": {
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: testInfraName + "-worker-a-wnjp7"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: testInfraName + "-worker-b-s48dq"}},
+			},
+			names:    []string{testInfraName + "-worker-a-wnjp7"},
+			expected: []string{testInfraName + "-worker-a-wnjp7"},
+		},
+		"mixed FQDN and short names": {
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: fqdnName(testInfraName + "-worker-a-wnjp7")}},
+				{ObjectMeta: metav1.ObjectMeta{Name: testInfraName + "-worker-b-s48dq"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: fqdnName(testInfraName + "-infra-a-zztd5")}},
+			},
+			names: []string{
+				testInfraName + "-worker-a-wnjp7",
+				testInfraName + "-worker-b-s48dq",
+			},
+			expected: []string{
+				fqdnName(testInfraName + "-worker-a-wnjp7"),
+				testInfraName + "-worker-b-s48dq",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			filtered := filterNodeObjectFromName(tc.nodes, tc.names)
+			require.Len(t, filtered, len(tc.expected))
+			for i, node := range filtered {
+				assert.Equal(t, tc.expected[i], node.Name)
+			}
+		})
+	}
+}
+
+func TestEvaluateExternalInstanceGroup(t *testing.T) {
+	t.Parallel()
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	gce.nodeInstancePrefix = testInfraName
+	zone := vals.ZoneName
+
+	// CAPG creates one master IG per zone. During install, the bootstrap node
+	// lands in the same IG as the master in that zone (e.g. both master-0 and
+	// bootstrap in <infra>-master-<zone>).
+	masterIGName := testInfraName + "-master-" + zone
+
+	// IG contains only the master. shouldReuse=true via hasAll.
+	err = gce.CreateInstanceGroup(&compute.InstanceGroup{Name: masterIGName}, zone)
+	require.NoError(t, err)
+	err = gce.AddInstancesToInstanceGroup(masterIGName, zone, []*compute.InstanceReference{
+		{Instance: fmt.Sprintf("zones/%s/instances/%s-master-0", zone, testInfraName)},
+	})
+	require.NoError(t, err)
+	masterIG, err := gce.GetInstanceGroup(masterIGName, zone)
+	require.NoError(t, err)
+
+	gceHostNames := sets.NewString(
+		testInfraName+"-master-0",
+		testInfraName+"-worker-a-wnjp7",
+		testInfraName+"-infra-a-zztd5",
+	)
+	shouldReuse, instanceNames, err := gce.evaluateExternalInstanceGroup(masterIG, zone, gceHostNames)
+	require.NoError(t, err)
+	assert.True(t, shouldReuse, "should reuse when all IG instances are in zone node list")
+	assert.True(t, instanceNames.Has(testInfraName+"-master-0"))
+
+	// During CAPG install (OCPBUGS-35256): bootstrap node is in the same master
+	// IG as master-0 (same zone). Bootstrap is not a k8s node so hasAll=false,
+	// but all instances share the infra prefix so allHavePrefix=true.
+	err = gce.AddInstancesToInstanceGroup(masterIGName, zone, []*compute.InstanceReference{
+		{Instance: fmt.Sprintf("zones/%s/instances/%s-bootstrap", zone, testInfraName)},
+	})
+	require.NoError(t, err)
+
+	shouldReuse, _, err = gce.evaluateExternalInstanceGroup(masterIG, zone, gceHostNames)
+	require.NoError(t, err)
+	assert.True(t, shouldReuse, "should reuse master IG even with bootstrap node present")
+}
+
+func TestFilterNodesWithExistingExternalInstanceGroups_FQDNNodes(t *testing.T) {
+	t.Parallel()
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	// Both prefixes are the infra name, matching real cloud config
+	gce.nodeInstancePrefix = testInfraName
+	gce.externalInstanceGroupsPrefix = testInfraName
+
+	zoneA := vals.ZoneName          // us-central1-b
+	zoneB := vals.SecondaryZoneName // us-central1-c
+
+	// GCE instances (short names) across two zones — masters, workers, infra
+	zoneAInstances := []string{
+		testInfraName + "-master-0",
+		testInfraName + "-worker-a-wnjp7",
+		testInfraName + "-infra-a-zztd5",
+	}
+	zoneBInstances := []string{
+		testInfraName + "-master-1",
+		testInfraName + "-worker-b-s48dq",
+		testInfraName + "-infra-b-2bn6x",
+	}
+	for _, name := range zoneAInstances {
+		err = gce.InsertInstance(gce.ProjectID(), zoneA, &compute.Instance{
+			Name: name,
+			Tags: &compute.Tags{Items: []string{name}},
+			Zone: zoneA,
+		})
+		require.NoError(t, err)
+	}
+	for _, name := range zoneBInstances {
+		err = gce.InsertInstance(gce.ProjectID(), zoneB, &compute.Instance{
+			Name: name,
+			Tags: &compute.Tags{Items: []string{name}},
+			Zone: zoneB,
+		})
+		require.NoError(t, err)
+	}
+
+	// External master IGs per zone (created by installer, match externalInstanceGroupsPrefix)
+	for _, z := range []struct {
+		zone   string
+		master string
+	}{
+		{zoneA, testInfraName + "-master-0"},
+		{zoneB, testInfraName + "-master-1"},
+	} {
+		igName := testInfraName + "-master-" + z.zone
+		err = gce.CreateInstanceGroup(&compute.InstanceGroup{Name: igName}, z.zone)
+		require.NoError(t, err)
+		err = gce.AddInstancesToInstanceGroup(igName, z.zone, []*compute.InstanceReference{
+			{Instance: fmt.Sprintf("zones/%s/instances/%s", z.zone, z.master)},
+		})
+		require.NoError(t, err)
+	}
+
+	// Nodes with FQDN names across both zones — masters, workers, infra
+	nodes := []*v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{
+			Name:   fqdnName(testInfraName + "-master-0"),
+			Labels: map[string]string{v1.LabelTopologyZone: zoneA},
+		}},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name:   fqdnName(testInfraName + "-worker-a-wnjp7"),
+			Labels: map[string]string{v1.LabelTopologyZone: zoneA},
+		}},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name:   fqdnName(testInfraName + "-infra-a-zztd5"),
+			Labels: map[string]string{v1.LabelTopologyZone: zoneA},
+		}},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name:   fqdnName(testInfraName + "-master-1"),
+			Labels: map[string]string{v1.LabelTopologyZone: zoneB},
+		}},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name:   fqdnName(testInfraName + "-worker-b-s48dq"),
+			Labels: map[string]string{v1.LabelTopologyZone: zoneB},
+		}},
+		{ObjectMeta: metav1.ObjectMeta{
+			Name:   fqdnName(testInfraName + "-infra-b-2bn6x"),
+			Labels: map[string]string{v1.LabelTopologyZone: zoneB},
+		}},
+	}
+
+	lbIGName := "k8s-ig--test-lb"
+	filteredNodes, existingIGLinks, err := gce.filterNodesWithExistingExternalInstanceGroups(lbIGName, nodes)
+	require.NoError(t, err)
+
+	// Masters filtered out (covered by external IGs), workers + infra remain
+	assert.Len(t, existingIGLinks, 2, "one master IG per zone should be reused")
+	assert.Len(t, filteredNodes, 4, "workers and infra nodes should remain for internal IG creation")
+
+	filteredNames := sets.NewString()
+	for _, n := range filteredNodes {
+		filteredNames.Insert(n.Name)
+	}
+	assert.True(t, filteredNames.Has(fqdnName(testInfraName+"-worker-a-wnjp7")))
+	assert.True(t, filteredNames.Has(fqdnName(testInfraName+"-worker-b-s48dq")))
+	assert.True(t, filteredNames.Has(fqdnName(testInfraName+"-infra-a-zztd5")))
+	assert.True(t, filteredNames.Has(fqdnName(testInfraName+"-infra-b-2bn6x")))
+	assert.False(t, filteredNames.Has(fqdnName(testInfraName+"-master-0")))
+	assert.False(t, filteredNames.Has(fqdnName(testInfraName+"-master-1")))
+}


### PR DESCRIPTION
OSD has node names as FQDNs, unlike any other OCP install. This means
our filtering logic for going []node -> compare  against []string ->
back to []node breaks, as we're comparing FQDN to canonical names.

This adds logging to capture the decision process, and tests to try
defend against potential regressions.

At the next rebase this should be folded into the 'reuse instance groups' patch
we carry.

It resolves OCPBUGS-78471. This bug has only been observed on OSD.

Happy logs from an OSD cluster running this patch: 

```
I0402 17:15:24.311877   20213 shared_informer.go:349] "Waiting for caches to sync" controller="service"
I0402 17:15:24.811954   20213 shared_informer.go:356] "Caches are synced" controller="service"
I0402 17:15:24.812192   20213 event.go:389] "Event occurred" object="default/test-ilb" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
W0402 17:15:34.156662   20213 gce_loadbalancer_internal_openshift.go:118] filterNodeObjectFromName: node "ocpbugs-78471-c5tkt-master-2.c.mobb-demo.internal" (canonical: "ocpbugs-78471-c5tkt-master-2") not found in GCE instance names [ocpbugs-78471-c5tkt-infra-c-9xnqq ocpbugs-78471-c5tkt-worker-c-qbp4s]
W0402 17:15:34.156691   20213 gce_loadbalancer_internal_openshift.go:118] filterNodeObjectFromName: node "ocpbugs-78471-c5tkt-master-0.c.mobb-demo.internal" (canonical: "ocpbugs-78471-c5tkt-master-0") not found in GCE instance names [ocpbugs-78471-c5tkt-worker-a-wnjp7 ocpbugs-78471-c5tkt-infra-a-zztd5]
W0402 17:15:34.156696   20213 gce_loadbalancer_internal_openshift.go:118] filterNodeObjectFromName: node "ocpbugs-78471-c5tkt-master-1.c.mobb-demo.internal" (canonical: "ocpbugs-78471-c5tkt-master-1") not found in GCE instance names [ocpbugs-78471-c5tkt-infra-b-2bn6x ocpbugs-78471-c5tkt-worker-b-s48dq]
I0402 17:17:07.176368   20213 event.go:389] "Event occurred" object="default/test-ilb" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0402 17:17:07.318159   20213 event.go:389] "Event occurred" object="openshift-ingress/router-default" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
I0402 17:17:10.686774   20213 gce_loadbalancer_external.go:83] ensureExternalLoadBalancer(aca422c9af83b47bcaeed6fcb975eca0): Attaching "gke.networking.io/l4-netlb-v1" finalizer to service router-default
I0402 17:17:15.102297   20213 gce_loadbalancer_external.go:184] ensureExternalLoadBalancer(aca422c9af83b47bcaeed6fcb975eca0(openshift-ingress/router-default)): Ensured IP address 136.116.134.210 (tier: Premium).
```

*As an aside - AI has been exceptionally bad at understanding this, hence the overly verbose comments (DO NOT REMOVE) and additional tests. This was with opus 4.6 + effort max, so if anyone's looking at this in future be cautious using AI tooling*