### PR TITLE
NO-JIRA: fix flaky test TestNodeTopologyCR_DeleteNode

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -334,6 +334,16 @@ func TestNodeTopologyCR_DeleteNode(t *testing.T) {
 	defer close(stopCh)
 	fakeInformerFactory.Start(stopCh)
 	go cloudAllocator.Run(stopCh)
+
+	// Wait for default node to be processed and default subnet to be added to CR.
+	// This avoids race condition with adding mscnode concurrently.
+	if err := wait.PollImmediate(time.Millisecond*500, wait.ForeverTestTimeout, func() (bool, error) {
+		ok, _ := verifySubnetsInCR(t, []string{"subnet-def"}, nodeTopologyClient)
+		return ok, nil
+	}); err != nil {
+		t.Fatalf("Failed to wait for default subnet in CR: %v", err)
+	}
+
 	mscnode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testNode",


### PR DESCRIPTION
Backports an exiting upstream fix for a flake we're seeing frequently in unit runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for node topology handling by waiting for reconciliation to finish before proceeding.
  * Added a check to ensure the expected default subnet is present before node add/delete scenarios run, reducing flaky test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->