### PR TITLE
NEEDS-JIRA: Fix node.kubernetes.io/exclude-from-external-load-balancers on masters

### DIFF
--- a/providers/gce/gce_fake.go
+++ b/providers/gce/gce_fake.go
@@ -86,7 +86,8 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		metricsCollector: newLoadBalancerMetrics(),
 		projectsBasePath: getProjectsBasePath(service.BasePath),
 		regional:         vals.Regional,
-		networkURL:       vals.NetworkURL,
+		networkURL:          vals.NetworkURL,
+		unsafeSubnetworkURL: vals.SubnetworkURL,
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c

--- a/providers/gce/gce_loadbalancer.go
+++ b/providers/gce/gce_loadbalancer.go
@@ -133,7 +133,7 @@ func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc 
 	// GCE load balancers do not support services with LoadBalancerClass set. LoadBalancerClass can't be updated for an existing load balancer, so here we don't need to clean any resources.
 	// Check API documentation for .Spec.LoadBalancerClass for details on when this field is allowed to be changed.
 	if svc.Spec.LoadBalancerClass != nil {
-		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, svc.Spec.LoadBalancerClass)
+		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
 		return nil, cloudprovider.ImplementedElsewhere
 	}
 
@@ -215,7 +215,7 @@ func (g *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc 
 	// GCE load balancers do not support services with LoadBalancerClass set. LoadBalancerClass can't be updated for an existing load balancer, so here we don't need to clean any resources.
 	// Check API documentation for .Spec.LoadBalancerClass for details on when this field is allowed to be changed.
 	if svc.Spec.LoadBalancerClass != nil {
-		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, svc.Spec.LoadBalancerClass)
+		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
 		return cloudprovider.ImplementedElsewhere
 	}
 

--- a/providers/gce/gce_loadbalancer_external_test.go
+++ b/providers/gce/gce_loadbalancer_external_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	compute "google.golang.org/api/compute/v1"
+	v1 "k8s.io/api/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"

--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -730,8 +730,23 @@ func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]s
 				parts := strings.Split(ins.Instance, "/")
 				groupInstances.Insert(parts[len(parts)-1])
 			}
+
+			// During bootstrap the bootstrap machine is placed in one of the master
+			// instance groups. However, the bootstrap machine does not have an
+			// associated Node. This will prevent us from considering this instance
+			// group for reuse because the instance group contains an instance which is
+			// not in the service's Node list. Consequently we will attempt to add the
+			// masters to a second instance group, which will fail with
+			// INSTANCE_IN_MULTIPLE_LOAD_BALANCED_IGS.
+			//
+			// To avoid this we explicitly exclude the bootstrap machine from
+			// consideration if it is present.
+			bootstrapInstanceName := fmt.Sprintf("%s-bootstrap", g.nodeInstancePrefix)
+			groupInstances.Delete(bootstrapInstanceName)
+
 			groupInstanceNames := groupInstances.UnsortedList()
-			if names.HasAll(groupInstanceNames...) || g.allHaveNodePrefix(groupInstanceNames) {
+			if names.HasAll(groupInstanceNames...) && groupInstances.Len() > 0 {
+				klog.V(2).Infof("ensureInternalInstanceGroups(%v): reusing external instance group %v, instances=%v", name, ig.Name, groupInstanceNames)
 				igLinks = append(igLinks, ig.SelfLink)
 				skip.Insert(groupInstances.UnsortedList()...)
 			}
@@ -756,15 +771,6 @@ func (g *Cloud) candidateExternalInstanceGroups(zone string) ([]*compute.Instanc
 		return nil, nil
 	}
 	return g.ListInstanceGroupsWithPrefix(zone, g.externalInstanceGroupsPrefix)
-}
-
-func (g *Cloud) allHaveNodePrefix(instances []string) bool {
-	for _, instance := range instances {
-		if !strings.HasPrefix(instance, g.nodeInstancePrefix) {
-			return false
-		}
-	}
-	return true
 }
 
 func (g *Cloud) ensureInternalInstanceGroupsDeleted(name string) error {

--- a/providers/gce/gce_loadbalancer_internal_openshift_test.go
+++ b/providers/gce/gce_loadbalancer_internal_openshift_test.go
@@ -1,0 +1,126 @@
+//go:build !providerless
+// +build !providerless
+
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute "google.golang.org/api/compute/v1"
+)
+
+// testInfraName is the cluster infrastructure name, used as both the
+// node-instance-prefix and external-instance-groups-prefix, as in real OCP
+// GCP clusters.
+const testInfraName = "test-cluster-a1b2c"
+
+func igSelfLink(projectID, zone, name string) string {
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instanceGroups/%s", projectID, zone, name)
+}
+
+// TestEnsureInternalInstanceGroupsExternalIGReuse tests the logic that decides
+// whether a pre-existing external (installer-managed) instance group should be
+// reused by the CCM's internal load balancer, or whether the CCM should create
+// its own instance group.
+//
+// In particular it covers:
+//   - OCPBUGS-35256: the bootstrap machine appears in a master IG during
+//     installation; it must not prevent the IG from being reused.
+//   - OCPBUGS-84569: masters labelled with
+//     node.kubernetes.io/exclude-from-external-load-balancers are filtered by
+//     the CCM framework before reaching this code.  The master IG must not be
+//     reused in that case, otherwise traffic is sent to control-plane machines.
+func TestEnsureInternalInstanceGroupsExternalIGReuse(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	zone := vals.ZoneName
+
+	masterIGName := testInfraName + "-master-" + zone
+	lbIGName := makeInstanceGroupName(vals.ClusterID)
+
+	for name, tc := range map[string]struct {
+		igInstances  []string // short instance names to place in the external IG
+		lbNodes      []string // short names of nodes passed to ensureInternalInstanceGroups
+		wantMasterIG bool     // whether the master IG self-link should appear in the result
+	}{
+		"all IG instances are known nodes so IG should be reused": {
+			igInstances:  []string{testInfraName + "-master-0"},
+			lbNodes:      []string{testInfraName + "-master-0"},
+			wantMasterIG: true,
+		},
+		"bootstrap instance is ignored and IG with only known nodes should be reused": {
+			igInstances:  []string{testInfraName + "-master-0", testInfraName + "-bootstrap"},
+			lbNodes:      []string{testInfraName + "-master-0"},
+			wantMasterIG: true,
+		},
+		"empty instance group should not be reused": {
+			igInstances:  []string{},
+			lbNodes:      []string{testInfraName + "-master-0"},
+			wantMasterIG: false,
+		},
+		"IG contains instance not in node list so IG should not be reused": {
+			igInstances:  []string{"other-cluster-master-0"},
+			lbNodes:      []string{testInfraName + "-master-0"},
+			wantMasterIG: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			gce, err := fakeGCECloud(vals)
+			require.NoError(t, err)
+			gce.nodeInstancePrefix = testInfraName
+			gce.externalInstanceGroupsPrefix = testInfraName
+
+			// Insert GCE instances and build Node objects for the nodes that
+			// will be passed to ensureInternalInstanceGroups.
+			nodes, err := createAndInsertNodes(gce, tc.lbNodes, zone)
+			require.NoError(t, err)
+
+			// Create the external master IG and populate it.
+			err = gce.CreateInstanceGroup(&compute.InstanceGroup{Name: masterIGName}, zone)
+			require.NoError(t, err)
+			if len(tc.igInstances) > 0 {
+				refs := make([]*compute.InstanceReference, len(tc.igInstances))
+				for i, inst := range tc.igInstances {
+					refs[i] = &compute.InstanceReference{
+						Instance: fmt.Sprintf("zones/%s/instances/%s", zone, inst),
+					}
+				}
+				err = gce.AddInstancesToInstanceGroup(masterIGName, zone, refs)
+				require.NoError(t, err)
+			}
+
+			igLinks, err := gce.ensureInternalInstanceGroups(lbIGName, nodes)
+			require.NoError(t, err)
+
+			masterIGLink := igSelfLink(vals.ProjectID, zone, masterIGName)
+			if tc.wantMasterIG {
+				assert.Contains(t, igLinks, masterIGLink, "expected master IG to be reused")
+			} else {
+				assert.NotContains(t, igLinks, masterIGLink, "expected master IG not to be reused")
+			}
+		})
+	}
+}

--- a/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_fake.go
+++ b/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_fake.go
@@ -86,7 +86,8 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		metricsCollector: newLoadBalancerMetrics(),
 		projectsBasePath: getProjectsBasePath(service.BasePath),
 		regional:         vals.Regional,
-		networkURL:       vals.NetworkURL,
+		networkURL:          vals.NetworkURL,
+		unsafeSubnetworkURL: vals.SubnetworkURL,
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c

--- a/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_loadbalancer.go
+++ b/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_loadbalancer.go
@@ -133,7 +133,7 @@ func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc 
 	// GCE load balancers do not support services with LoadBalancerClass set. LoadBalancerClass can't be updated for an existing load balancer, so here we don't need to clean any resources.
 	// Check API documentation for .Spec.LoadBalancerClass for details on when this field is allowed to be changed.
 	if svc.Spec.LoadBalancerClass != nil {
-		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, svc.Spec.LoadBalancerClass)
+		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
 		return nil, cloudprovider.ImplementedElsewhere
 	}
 
@@ -215,7 +215,7 @@ func (g *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc 
 	// GCE load balancers do not support services with LoadBalancerClass set. LoadBalancerClass can't be updated for an existing load balancer, so here we don't need to clean any resources.
 	// Check API documentation for .Spec.LoadBalancerClass for details on when this field is allowed to be changed.
 	if svc.Spec.LoadBalancerClass != nil {
-		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, svc.Spec.LoadBalancerClass)
+		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
 		return cloudprovider.ImplementedElsewhere
 	}
 

--- a/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_loadbalancer_internal.go
+++ b/vendor/k8s.io/cloud-provider-gcp/providers/gce/gce_loadbalancer_internal.go
@@ -730,8 +730,23 @@ func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]s
 				parts := strings.Split(ins.Instance, "/")
 				groupInstances.Insert(parts[len(parts)-1])
 			}
+
+			// During bootstrap the bootstrap machine is placed in one of the master
+			// instance groups. However, the bootstrap machine does not have an
+			// associated Node. This will prevent us from considering this instance
+			// group for reuse because the instance group contains an instance which is
+			// not in the service's Node list. Consequently we will attempt to add the
+			// masters to a second instance group, which will fail with
+			// INSTANCE_IN_MULTIPLE_LOAD_BALANCED_IGS.
+			//
+			// To avoid this we explicitly exclude the bootstrap machine from
+			// consideration if it is present.
+			bootstrapInstanceName := fmt.Sprintf("%s-bootstrap", g.nodeInstancePrefix)
+			groupInstances.Delete(bootstrapInstanceName)
+
 			groupInstanceNames := groupInstances.UnsortedList()
-			if names.HasAll(groupInstanceNames...) || g.allHaveNodePrefix(groupInstanceNames) {
+			if names.HasAll(groupInstanceNames...) && groupInstances.Len() > 0 {
+				klog.V(2).Infof("ensureInternalInstanceGroups(%v): reusing external instance group %v, instances=%v", name, ig.Name, groupInstanceNames)
 				igLinks = append(igLinks, ig.SelfLink)
 				skip.Insert(groupInstances.UnsortedList()...)
 			}
@@ -756,15 +771,6 @@ func (g *Cloud) candidateExternalInstanceGroups(zone string) ([]*compute.Instanc
 		return nil, nil
 	}
 	return g.ListInstanceGroupsWithPrefix(zone, g.externalInstanceGroupsPrefix)
-}
-
-func (g *Cloud) allHaveNodePrefix(instances []string) bool {
-	for _, instance := range instances {
-		if !strings.HasPrefix(instance, g.nodeInstancePrefix) {
-			return false
-		}
-	}
-	return true
 }
 
 func (g *Cloud) ensureInternalInstanceGroupsDeleted(name string) error {


### PR DESCRIPTION
We previously used allHaveNodePrefix() to ensure that if a master instance group contained the bootstrap machine this would not cause it to be excluded from re-use. This worked because the bootstrap machine's name has the same prefix as all other machines in the cluster.

However, this logic unconditionally always included the master instance group. If the masters are labelled with node.kubernetes.io/exclude-from-external-load-balancers the CCM framework code will have filtered the Nodes before passing them to provider-GCP. But this logic meant we added them anyway, sending unintended traffic to the control plane machines.

Manual backport of #121

Additionally backports some small test fixes required for the tests to compile and pass. Required so we can execute the new test added for the bugfix.

/hold until the parent PRs merge
