### PR TITLE
OCPBUGS-99011: Bump golang to 1.26.5 for CVE-2026-42504

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module k8s.io/cloud-provider-gcp
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.26.5
 
 require (
 	github.com/evanphx/json-patch v5.9.0+incompatible

--- a/metis/go.mod
+++ b/metis/go.mod
@@ -1,8 +1,6 @@
 module k8s.io/metis
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/providers/go.mod
+++ b/providers/go.mod
@@ -1,8 +1,6 @@
 module k8s.io/cloud-provider-gcp/providers
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.26.5
 
 require (
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,8 +1,6 @@
 module k8s.io/cloud-provider-gcp/test/e2e
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.26.5
 
 require (
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0


### PR DESCRIPTION
Bumps go directive in all go.mod files from 1.25.0 to 1.26.5 to pick up the fix for CVE-2026-42504 (MIME header DoS).

Force the use of golang 1.26.5 by bumping the go.mod files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go version requirement to 1.26.5 across all modules.
  * Removed the previous explicit Go toolchain pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->